### PR TITLE
fix: 헤더 컴포넌트에 카드 썸네일이 더 높아지는 현상 수정

### DIFF
--- a/src/components/header/styles.css.ts
+++ b/src/components/header/styles.css.ts
@@ -2,6 +2,7 @@ import { style } from '@vanilla-extract/css'
 
 import { theme } from '#shared/theme.css'
 import { sprinkles } from '#components/shared/sprinkles.css'
+import { MAX_Z_INDEX } from '#constants'
 
 export const header = style({
   position: 'sticky',
@@ -10,6 +11,7 @@ export const header = style({
   height: '60px',
   backgroundColor: `${theme.color.white}`,
   borderBottom: `1px solid ${theme.borderColor.grayOpacity}`,
+  zIndex: MAX_Z_INDEX,
 })
 
 export const navbar = style({

--- a/src/components/header/styles.css.ts
+++ b/src/components/header/styles.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css'
 
 import { theme } from '#shared/theme.css'
 import { sprinkles } from '#components/shared/sprinkles.css'
-import { MAX_Z_INDEX } from '#constants'
+import { Z_INDEX } from '#constants'
 
 export const header = style({
   position: 'sticky',
@@ -11,7 +11,7 @@ export const header = style({
   height: '60px',
   backgroundColor: `${theme.color.white}`,
   borderBottom: `1px solid ${theme.borderColor.grayOpacity}`,
-  zIndex: MAX_Z_INDEX,
+  zIndex: Z_INDEX.header,
 })
 
 export const navbar = style({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,3 @@
 export const MESSAGE = 'Next Template Copiest'
 export const DEFAULT_POSTS_SIZE = 10
+export const MAX_Z_INDEX = 99999

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
 export const MESSAGE = 'Next Template Copiest'
 export const DEFAULT_POSTS_SIZE = 10
-export const MAX_Z_INDEX = 99999
+export const Z_INDEX = {
+  header: 1,
+}


### PR DESCRIPTION
> close #28 

## 변경 사항
- z-index로 가장 최상단에 위치시킴 (상수화)

## 스크린샷
![image](https://user-images.githubusercontent.com/76392809/148676009-8cc4ec04-871a-40eb-ae92-60c0683ff2bf.png)
