### PR TITLE
[#32]: footer 컴포넌트 구현

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,0 +1,17 @@
+import config from 'config'
+
+import * as styles from './styles.css'
+
+export default function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <span className={styles.contact}>
+        # Contact :{' '}
+        <a className={styles.mail} href={`mailto:${config.author.contacts.email}`}>
+          {config.author.contacts.email}
+        </a>
+      </span>
+      <span className={styles.copyright}>Designed by Fronttigger © 2022 All rights reserved.</span>
+    </footer>
+  )
+}

--- a/src/components/footer/styles.css.ts
+++ b/src/components/footer/styles.css.ts
@@ -1,0 +1,37 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '#shared/theme.css'
+import { mediaQuery } from '#components/shared/sprinkles.css'
+
+export const footer = style({
+  padding: '20px',
+  color: '#598197',
+  textAlign: 'center',
+  lineHeight: '18px',
+  letterSpacing: '1.6px',
+  backgroundColor: '#f0f4f6',
+  fontSize: '13px',
+  fontFamily: theme.font.footer,
+  '@media': {
+    [mediaQuery.mobile]: {
+      fontSize: theme.fontSize.tiny,
+    },
+  },
+})
+
+export const contact = style({
+  display: 'block',
+})
+
+export const mail = style({
+  color: theme.color.bluegray,
+  selectors: {
+    '&:active, &:link, &:visited': {
+      color: theme.color.bluegray,
+    },
+  },
+})
+
+export const copyright = style({
+  display: 'block',
+})

--- a/src/components/layout/styles.css.ts
+++ b/src/components/layout/styles.css.ts
@@ -11,7 +11,7 @@ export const container = style([
     },
   }),
   {
-    maxWidth: '720px',
+    maxWidth: '700px',
     margin: 'auto',
   },
 ])

--- a/src/components/shared/theme.css.ts
+++ b/src/components/shared/theme.css.ts
@@ -53,6 +53,7 @@ export const theme = createGlobalTheme(':root', {
   },
   font: {
     header: 'Bebas Neue, cursive',
+    footer: 'Barlow Condensed, sans-serif',
     cardTitle: 'Do Hyeon, sans-serif',
   },
   borderColor: {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { RecoilRoot } from 'recoil'
 import '#shared/globalStyles.css.ts'
 import Header from '#components/header'
 import Layout from '#components/layout'
+import Footer from '#components/footer'
 
 function App({ Component, pageProps }: AppProps) {
   const Router = useRouter()
@@ -54,6 +55,7 @@ function App({ Component, pageProps }: AppProps) {
       <Layout>
         <Component {...pageProps} />
       </Layout>
+      <Footer />
     </RecoilRoot>
   )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,7 +15,7 @@ class MyDocument extends Document {
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Do+Hyeon&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@400;500&family=Bebas+Neue&family=Do+Hyeon&display=swap"
             rel="stylesheet"
           />
         </Head>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { GetStaticProps } from 'next'
 import Link from 'next/link'
 import config from 'config'
 
-import { cardContainer } from './styles.css'
+import * as styles from './styles.css'
 
 import PageSEO from '#components/shared/SEO/PageSEO'
 import Card from '#components/card'
@@ -14,9 +14,10 @@ function IndexPage({ posts }: { posts: Post[] }) {
   return (
     <>
       <PageSEO title="Home" url={config.url} />
-      <ul>
+      <h1 className={styles.title}>Latest</h1>
+      <ul className={styles.container}>
         {posts.map(({ frontMatter, slug }, index) => (
-          <li key={index} className={cardContainer}>
+          <li key={index} className={styles.cardContainer}>
             <Link href={`/${slug.year}/${slug.subject}/${slug.title}`}>
               <a>
                 <Card frontMatter={frontMatter} />

--- a/src/pages/styles.css.ts
+++ b/src/pages/styles.css.ts
@@ -1,12 +1,27 @@
 import { style } from '@vanilla-extract/css'
 
 import { mediaQuery } from '#components/shared/sprinkles.css'
+import { theme } from '#components/shared/theme.css'
+
+export const title = style({
+  margin: `${theme.space.xxxlarge} 0 ${theme.space.xlarge}`,
+  color: theme.color.darkblue,
+  fontSize: theme.space.xxlarge,
+  fontWeight: theme.fontWeight.bold,
+})
+
+export const container = style({
+  marginBottom: '80px',
+})
 
 export const cardContainer = style({
-  marginTop: '80px',
+  marginTop: '60px',
+  ':first-child': {
+    marginTop: 0,
+  },
   '@media': {
     [mediaQuery.mobile]: {
-      marginTop: '40px',
+      marginTop: '50px',
     },
   },
 })


### PR DESCRIPTION
> close #32 

## 변경 사항
- Footer 컴포넌트 구현 및 적용
- 메인 페이지 타이틀 추가
- 레이아웃 maxWitdh 변경 (720px -> 700px)

## 스크린샷
![image](https://user-images.githubusercontent.com/76392809/149189139-57a4d2b0-2be1-4485-a884-a9a1b8365485.png)

