### PR TITLE
enh: 모바일 대응 더 넓게 브레이크포인트 수정

### DIFF
--- a/src/components/shared/sprinkles.css.ts
+++ b/src/components/shared/sprinkles.css.ts
@@ -3,8 +3,8 @@ import { defineProperties, createSprinkles } from '@vanilla-extract/sprinkles'
 import { theme } from './theme.css'
 
 export const mediaQuery = {
-  mobile: 'screen and (max-width: 375px)',
-  tablet: 'screen and (min-width: 376px)',
+  mobile: 'screen and (max-width: 576px)',
+  tablet: 'screen and (min-width: 577px)',
   desktop: 'screen and (min-width: 769px)',
 }
 


### PR DESCRIPTION
> close #46 

## 변경 사항
- mobile breakpoint max-width 375px -> 576px
- tablet breakpoint min-width 577px

## 스크린샷
![image](https://user-images.githubusercontent.com/76392809/150520484-e4a44707-cc5f-4205-8d82-4828298ec5af.png)
