### PR TITLE
enh: 최초 접근시 무조건 전체 포스트 상태에 담도록 처리

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,7 @@
 import { GetStaticProps } from 'next'
 import Link from 'next/link'
+import { useEffect } from 'react'
+import { useRecoilState } from 'recoil'
 import config from 'config'
 
 import * as styles from '#shared/styles/pages/posts/styles.css'
@@ -8,14 +10,23 @@ import Card from '#components/card'
 import { Post } from '#types/post'
 import { getAllPosts } from '#utils/posts'
 import { DEFAULT_POSTS_SIZE } from '#constants'
+import { allPostsState } from '#store/posts'
 
-function IndexPage({ posts }: { posts: Post[] }) {
+function IndexPage({ allPosts, latestPosts }: { allPosts: Post[]; latestPosts: Post[] }) {
+  const [posts, setPosts] = useRecoilState(allPostsState)
+
+  useEffect((): void => {
+    if (posts.length === 0) {
+      setPosts(allPosts)
+    }
+  }, [allPosts, posts.length, setPosts])
+
   return (
     <>
       <PageSEO title="Home" url={config.url} />
       <h1 className={styles.title}>Latest</h1>
       <ul className={styles.container}>
-        {posts.map(({ frontMatter, slug }, index) => (
+        {latestPosts.map(({ frontMatter, slug }, index) => (
           <li key={index} className={styles.cardContainer}>
             <Link href={`/${slug.year}/${slug.subject}/${slug.title}`}>
               <a>
@@ -32,11 +43,12 @@ function IndexPage({ posts }: { posts: Post[] }) {
 export default IndexPage
 
 export const getStaticProps: GetStaticProps = async () => {
-  const posts = await getAllPosts()
+  const allPosts = await getAllPosts()
 
   return {
     props: {
-      posts: posts.slice(0, DEFAULT_POSTS_SIZE),
+      allPosts,
+      latestPosts: allPosts.slice(0, DEFAULT_POSTS_SIZE),
     },
   }
 }

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { GetStaticProps } from 'next'
 import Link from 'next/link'
 import { InView } from 'react-intersection-observer'
-import { useSetRecoilState, useRecoilValue } from 'recoil'
+import { useSetRecoilState, useRecoilValue, useRecoilState } from 'recoil'
 import config from 'config'
 
 import * as styles from '#shared/styles/pages/posts/styles.css'
@@ -13,10 +13,10 @@ import { Post } from '#types/post'
 import { getAllPosts } from '#utils/posts'
 
 function PostsPage({ allPosts }: { allPosts: Post[] }) {
-  const setPosts = useSetRecoilState(allPostsState)
-  const setPage = useSetRecoilState(pageState)
+  const [posts, setPosts] = useRecoilState(allPostsState)
   const currentPosts = useRecoilValue(currentPostsState)
   const hasNextPostsPage = useRecoilValue(hasNextPostsPageState)
+  const setPage = useSetRecoilState(pageState)
 
   const handleChangeInview = (inView: boolean, index: number): void => {
     if (inView && index === currentPosts.length - 3 && hasNextPostsPage) {
@@ -24,7 +24,11 @@ function PostsPage({ allPosts }: { allPosts: Post[] }) {
     }
   }
 
-  useEffect((): void => setPosts(allPosts), [allPosts, setPosts])
+  useEffect((): void => {
+    if (posts.length === 0) {
+      setPosts(allPosts)
+    }
+  }, [allPosts, posts.length, setPosts])
 
   return (
     <>


### PR DESCRIPTION
> close #48 

## 이슈
각 index, posts 로 최초 접근시에는 문제가 없지만, index 접근 후 posts로 접근하면 포스트가 없는 채로 아주 잠깐 렌더링 되었다가 포스트가 다시 리렌더 되는 현상 발견

## 변경 사항
- pages/index.tsx posts 검증 추가
- pages/posts/index.tsx posts 검증 추가
- index로 접근 했을 때 글로벌 포스트 상태에 넣고, 이 상태를 각 포스트를 보여주는 컴포넌트에서 접근시 검증하여 있으면 있는걸 그대로 그려주도록 처리 (그런데 페이지가 2개 있어서 망정이지 만약 이런 페이지들이 많으면..? 🤔  더 좋은 방법이 있을 것 같음..)