### PR TITLE
enh: 카드 컴포넌트 스타일 수정 & 마크다운 이미지 컴포넌트 100% 아닐 때 대응

### DIFF
--- a/posts/2022/react/contextreducer6.mdx
+++ b/posts/2022/react/contextreducer6.mdx
@@ -41,7 +41,12 @@ Context API가 Redux와 같은 상태관리 라이브러리 대용으로 사용�
 
 리액트 공식문서에 따르면 생각과는 다르게 전혀 다른 말이 적혀있습니다.
 
-![Context API DOCS](/images/2022/01/react/contextreact.png)
+<img
+  src="/images/2022/01/react/contextreact.png"
+  width="100%"
+  height="100%"
+  alt="Context API DOCS"
+/>
 
 위 말에서 그 어디에도 **상태관리**라는 말은 찾아볼 수가 없죠
 

--- a/posts/2022/react/contextreducer6.mdx
+++ b/posts/2022/react/contextreducer6.mdx
@@ -41,12 +41,7 @@ Context API가 Redux와 같은 상태관리 라이브러리 대용으로 사용�
 
 리액트 공식문서에 따르면 생각과는 다르게 전혀 다른 말이 적혀있습니다.
 
-<img
-  src="/images/2022/01/react/contextreact.png"
-  width="100%"
-  height="100%"
-  alt="Context API DOCS"
-/>
+![Context API DOCS](/images/2022/01/react/contextreact.png)
 
 위 말에서 그 어디에도 **상태관리**라는 말은 찾아볼 수가 없죠
 

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -10,7 +10,7 @@ export default function Card({ frontMatter }: { frontMatter: FrontMatter }) {
   return (
     <article className={styles.container}>
       <div className={styles.imageContainer}>
-        <Image src={thumbnailImg || ''} width="160px" height="134px" />
+        <Image src={thumbnailImg || ''} width="192px" height="144px" />
       </div>
       <div className={styles.textContainer}>
         <h3 className={styles.title}>{postTitle}</h3>

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -10,7 +10,7 @@ export default function Card({ frontMatter }: { frontMatter: FrontMatter }) {
   return (
     <article className={styles.container}>
       <div className={styles.imageContainer}>
-        <Image src={thumbnailImg || ''} width="160px" height="133px" />
+        <Image src={thumbnailImg || ''} width="160px" height="134px" />
       </div>
       <div className={styles.textContainer}>
         <h3 className={styles.title}>{postTitle}</h3>

--- a/src/components/card/index.tsx
+++ b/src/components/card/index.tsx
@@ -10,7 +10,7 @@ export default function Card({ frontMatter }: { frontMatter: FrontMatter }) {
   return (
     <article className={styles.container}>
       <div className={styles.imageContainer}>
-        <Image src={thumbnailImg || ''} width="160px" height="130px" />
+        <Image src={thumbnailImg || ''} width="160px" height="133px" />
       </div>
       <div className={styles.textContainer}>
         <h3 className={styles.title}>{postTitle}</h3>

--- a/src/components/card/styles.css.ts
+++ b/src/components/card/styles.css.ts
@@ -15,8 +15,8 @@ export const imageContainer = style([
     },
   }),
   {
-    minWidth: '160px',
-    height: '134px',
+    minWidth: '192px',
+    height: '144px',
     marginRight: theme.space.xlarge,
   },
 ])

--- a/src/components/card/styles.css.ts
+++ b/src/components/card/styles.css.ts
@@ -16,7 +16,7 @@ export const imageContainer = style([
   }),
   {
     minWidth: '160px',
-    height: '133px',
+    height: '134px',
     marginRight: theme.space.xlarge,
   },
 ])
@@ -51,7 +51,7 @@ export const title = style([
   {
     fontWeight: theme.fontWeight.bold,
     color: theme.colors.domain.card.title,
-    lineHeight: '1.04',
+    lineHeight: '1.05',
   },
   twoLineEllipsis,
 ])

--- a/src/components/card/styles.css.ts
+++ b/src/components/card/styles.css.ts
@@ -16,7 +16,7 @@ export const imageContainer = style([
   }),
   {
     minWidth: '160px',
-    height: '130px',
+    height: '133px',
     marginRight: theme.space.xlarge,
   },
 ])
@@ -51,6 +51,7 @@ export const title = style([
   {
     fontWeight: theme.fontWeight.bold,
     color: theme.colors.domain.card.title,
+    lineHeight: '1.04',
   },
   twoLineEllipsis,
 ])

--- a/src/components/shared/MDX/Image/index.tsx
+++ b/src/components/shared/MDX/Image/index.tsx
@@ -3,8 +3,8 @@ import * as styles from './styles.css'
 const Image = ({
   src,
   alt,
-  width,
-  height,
+  width = '100%',
+  height = '100%',
 }: React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>) => (
   <img className={styles.image} src={src || ''} alt={alt} width={width} height={height} />
 )

--- a/src/components/shared/MDX/Image/index.tsx
+++ b/src/components/shared/MDX/Image/index.tsx
@@ -1,8 +1,12 @@
+import * as styles from './styles.css'
+
 const Image = ({
   src,
   alt,
+  width,
+  height,
 }: React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>) => (
-  <img src={src || ''} alt={alt} width="100%" height="100%" />
+  <img className={styles.image} src={src || ''} alt={alt} width={width} height={height} />
 )
 
 export default Image

--- a/src/components/shared/MDX/Image/styles.css.ts
+++ b/src/components/shared/MDX/Image/styles.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css'
+
+export const image = style({
+  display: 'block',
+  margin: '0 auto',
+})

--- a/src/components/shared/styles/pages/postDetail/styles.css.ts
+++ b/src/components/shared/styles/pages/postDetail/styles.css.ts
@@ -26,7 +26,11 @@ export const title = style([
       mobile: 'large',
     },
   }),
-  { fontWeight: theme.fontWeight.bold, color: theme.colors.domain.detail.title },
+  {
+    fontWeight: theme.fontWeight.bold,
+    color: theme.colors.domain.detail.title,
+    textAlign: 'center',
+  },
 ])
 
 export const date = style([


### PR DESCRIPTION
> close #50
> close #52 

## 변경 사항
- MDX/image width, height parameter로 받아오기 (무조건 100%일 경우 작은 이미지의 경우에도 꽉차는 현상이 있어서 화질구지가 되어버림) -> 이 부분은 추후 개선이 필요함
- 이미지가 100%가 아닐 때 가운데 정렬 처리
- card 컴포넌트 한글 입력시 데스크탑 환경에서 살짝 overflow하는 현상이 있어 line-height 수정
- card 컴포넌트 썸네일 이미지 192x144로 변경

## 스크린샷
![image](https://user-images.githubusercontent.com/76392809/150646935-8e999a5d-447e-4c78-954e-1fa34a92cd56.png)
